### PR TITLE
API Enhancement // strategy is now a module, not function capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ iex(10)> TextChunker.split(text)
 ]
 
 text = "This is a sample text. It will be split into properly-sized chunks using the TextChunker library."
-opts = [chunk_size: 50, chunk_overlap: 5, format: :plaintext, strategy: &TextChunker.Strategies.RecursiveChunk.split/2]
+opts = [chunk_size: 50, chunk_overlap: 5, format: :plaintext, strategy: TextChunker.Strategies.RecursiveChunk]
 
 iex(10)> TextChunker.split(text, opts)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ text = "Your text to be split..."
 chunks = TextChunker.split(text)
 ```
 
-This will chunk up your text using the default parameters - a chunk size of `1000`, chunk overlap of `200`, format of :`plaintext` and using the `RecursiveChunk` strategy.
+This will chunk up your text using the default parameters - a chunk size of `1000`, chunk overlap of `200`, format of `:plaintext` and using the `RecursiveChunk` strategy.
 
 The split method returns `Chunks` of your text. These chunks include the start and end bytes of each chunk.
 
@@ -67,7 +67,7 @@ If you wish to adjust these parameters, configuration can optionally be passed v
 
   - `chunk_size` -  The approximate target chunk size, as measured per code points. This means that both `a` and `👻` count as one. Chunks will not exceed this maximum, but may sometimes be smaller. **Important note** This means that graphemes *may* be split. For example, `👩‍🚒` may be split into `👩,🚒` or not depending on the split boundary.
   - `chunk_overlap` - The contextual overlap between chunks, as measured per code point. Overlap is *not* guaranteed; again this should be treated as a maximum. The size of an individual overlap will depend on the semantics of the text being split.
-  - `format` (informs separator selection). Because we are trying to preserve meaning between the chunks, the format of the text we are splitting is important. It's important to split newlines in plain text; it's important to split `###` headings in markdown.
+  - `format` - What informs separator selection. Because we are trying to preserve meaning between the chunks, the format of the text we are splitting is important. It's important to split newlines in plain text; it's important to split `###` headings in markdown.
 
 ```elixir
 text = """

--- a/lib/text_chunker.ex
+++ b/lib/text_chunker.ex
@@ -13,7 +13,7 @@ defmodule TextChunker do
   @default_opts [
     chunk_size: 2000,
     chunk_overlap: 200,
-    strategy: &RecursiveChunk.split/2,
+    strategy: RecursiveChunk,
     format: :plaintext
   ]
 
@@ -43,6 +43,6 @@ defmodule TextChunker do
   def split(text, opts \\ []) do
     opts = Keyword.merge(@default_opts, opts)
 
-    opts[:strategy].(text, opts)
+    opts[:strategy].split(text, opts)
   end
 end


### PR DESCRIPTION
connects to #11 

### Overview

Refactors the code to use a module which implements the `TextChunker.ChunkerBehaviour`, instead of a function captures, for the `:strategy` option.

This would be a breaking change for anyone passing in their own strategy - however, there is only *one* strategy to choose from at the moment, so I think it's fine 👍 