### PR TITLE
Chore // Update CI to actually run tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Overview

Tweaks the CI to actually run tests, so we can actually merge PRs from external forks

We can't merge things like : #48

because that's a PR, not a push