### PR TITLE
Release // Prepare for 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add TextChunker to your mix.exs:
 ```elixir
 def deps do
   [
-    {:text_chunker, "~> 0.5.0"}
+    {:text_chunker, "~> 0.5.1"}
   ]
 end
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.5.1   | :white_check_mark: |
 | 0.5.0   | :white_check_mark: |
 | 0.4.0   | :white_check_mark: |
 | 0.3.2   | :white_check_mark: |

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TextChunker.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/revelrylabs/text_chunker_ex"
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [


### PR DESCRIPTION
I went for the patch version, because I really don't want to go up to 0.6 so soon, but I could also be convinced that this should instead be 0.6.0 (because this will affect the chunks that users of TextChunker get back).