### PR TITLE
Preparation for Release // 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add TextChunker to your mix.exs:
 ```elixir
 def deps do
   [
-    {:text_chunker, "~> 0.5.1"}
+    {:text_chunker, "~> 0.5.2"}
   ]
 end
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.5.2   | :white_check_mark: |
 | 0.5.1   | :white_check_mark: |
 | 0.5.0   | :white_check_mark: |
 | 0.4.0   | :white_check_mark: |

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TextChunker.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/revelrylabs/text_chunker_ex"
-  @version "0.5.1"
+  @version "0.5.2"
 
   def project do
     [


### PR DESCRIPTION
### Overview

Solves a edge-case bug that causes the chunker to infinitely recurse on silly non-splittable chunks of text. This is an edge case, but in one of our applications we were testing out test (eg, `String.duplicate("a", 150_000)`). 

This release fixes that by falling back to bog-standard splitting (using simply chunk sizes and overlap) if a chunk is too big once the recursive splitter has exhausted all the other ways of splitting things.

That's the only thing in this release!