### PR TITLE
Track split sizes incrementally in the merge loop

### DIFF
--- a/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
+++ b/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
@@ -133,17 +133,10 @@ defmodule TextChunker.Strategies.RecursiveChunk do
   end
 
   ### **Chunk Assembly:**
-  defp merge_good_splits_into_final_chunks(
-         good_splits,
-         final_chunks,
-         chunk_size,
-         chunk_overlap,
-         get_chunk_size,
-         separator \\ ""
-       ) do
+  defp merge_good_splits_into_final_chunks(good_splits, final_chunks, chunk_size, chunk_overlap, get_chunk_size) do
     case good_splits do
       [] -> final_chunks
-      _ -> final_chunks ++ merge_splits_into_chunks(good_splits, chunk_size, chunk_overlap, get_chunk_size, separator)
+      _ -> final_chunks ++ merge_splits_into_chunks(good_splits, chunk_size, chunk_overlap, get_chunk_size)
     end
   end
 
@@ -166,119 +159,71 @@ defmodule TextChunker.Strategies.RecursiveChunk do
 
   defp fits_in_chunk?(%Chunk{text: text}, max_chunk_size, get_chunk_size), do: get_chunk_size.(text) <= max_chunk_size
 
-  # Merges splits into chunks that respect chunk_size, adding the overlap between chunks
-  defp merge_splits_into_chunks(splits, chunk_size, chunk_overlap, get_chunk_size, current_separator) do
-    {final_chunks, current_splits} =
-      Enum.reduce(splits, {[], []}, fn split, {final_chunks, current_splits} ->
-        current_texts = Enum.map(current_splits, & &1.text)
+  # Merges splits into chunks that respect chunk_size, adding the overlap between chunks.
+  #
+  # Each split is measured once and chunk boundaries are decided on a running
+  # sum of those sizes. Each flushed chunk is re-measured before it is emitted.
+  defp merge_splits_into_chunks(splits, chunk_size, chunk_overlap, get_chunk_size) do
+    {final_chunks, current_splits, _current_size} =
+      Enum.reduce(splits, {[], [], 0}, fn split, {final_chunks, current_splits, current_size} ->
+        split_size = get_chunk_size.(split.text)
 
-        bigger_than_chunk? =
-          splits_bigger_than_chunk?(
-            split.text,
-            current_texts,
-            current_separator,
-            chunk_size,
-            get_chunk_size
-          )
+        if current_size + split_size > chunk_size and !Enum.empty?(current_splits) do
+          chunk = build_chunk(current_splits)
 
-        if bigger_than_chunk? and !Enum.empty?(current_splits) do
-          # Create chunk from current_splits
-          chunk_text = join_splits(current_texts, current_separator)
+          if get_chunk_size.(chunk.text) > chunk_size do
+            # The overlap is dropped so start bytes stay monotonic.
+            fallback_chunks = create_fallback_chunks(chunk, chunk_size, chunk_overlap, get_chunk_size)
+            {final_chunks ++ fallback_chunks, [{split, split_size}], split_size}
+          else
+            # Calculate overlap for next chunk, ensuring room for the new split
+            {overlap_splits, overlap_size} =
+              trim_splits_for_overlap(current_splits, current_size, chunk_overlap, chunk_size, split_size)
 
-          chunk_start_pos =
-            case current_splits do
-              [first_split | _] -> first_split.start_byte
-              [] -> split.start_byte
-            end
-
-          # Calculate overlap for next chunk, ensuring room for the new split
-          overlap_splits =
-            trim_splits_for_overlap(
-              current_splits,
-              chunk_overlap,
-              chunk_size,
-              split.text,
-              get_chunk_size,
-              current_separator
-            )
-
-          final_chunk = %Chunk{
-            start_byte: chunk_start_pos,
-            end_byte: chunk_start_pos + byte_size(chunk_text),
-            text: chunk_text
-          }
-
-          new_current_splits = overlap_splits ++ [split]
-
-          {final_chunks ++ [final_chunk], new_current_splits}
+            {final_chunks ++ [chunk], overlap_splits ++ [{split, split_size}], overlap_size + split_size}
+          end
         else
-          {final_chunks, current_splits ++ [split]}
+          {final_chunks, current_splits ++ [{split, split_size}], current_size + split_size}
         end
       end)
 
     # Handle leftover splits
-    leftover_chunk =
-      case current_splits do
-        [] ->
-          nil
+    case current_splits do
+      [] ->
+        final_chunks
 
-        _ ->
-          chunk_text = join_splits(Enum.map(current_splits, & &1.text), current_separator)
-
-          chunk_start_pos =
-            case current_splits do
-              [first_split | _] -> first_split.start_byte
-              [] -> 0
-            end
-
-          %Chunk{
-            start_byte: chunk_start_pos,
-            end_byte: chunk_start_pos + byte_size(chunk_text),
-            text: chunk_text
-          }
-      end
-
-    case leftover_chunk do
-      nil -> final_chunks
-      chunk -> final_chunks ++ [chunk]
+      _ ->
+        final_chunks ++ create_fallback_chunks(build_chunk(current_splits), chunk_size, chunk_overlap, get_chunk_size)
     end
   end
 
-  # Checks if adding split_text to current_splits would exceed chunk_size
-  defp splits_bigger_than_chunk?(split_text, current_splits_texts, separator, chunk_size, get_chunk_size) do
-    merged = join_splits(current_splits_texts ++ [split_text], separator)
-    get_chunk_size.(merged || "") > chunk_size
-  end
+  defp build_chunk([{first_split, _size} | _] = current_splits) do
+    chunk_text = Enum.map_join(current_splits, fn {split, _size} -> split.text end)
 
-  # Using the given separator, joins the strings in the array current_splits together
-  defp join_splits(current_splits, separator) do
-    result = Enum.join(current_splits, separator)
-    if String.equivalent?(result, ""), do: nil, else: result
+    %Chunk{
+      start_byte: first_split.start_byte,
+      end_byte: first_split.start_byte + byte_size(chunk_text),
+      text: chunk_text
+    }
   end
 
   # Trims splits kept for the overlap of the next chunk.
   # Drops splits from the front until:
   # 1. remaining size <= chunk_overlap, AND
-  # 2. there's room to add next_split_text without exceeding chunk_size
-  defp trim_splits_for_overlap([], _chunk_overlap, _chunk_size, _next_split_text, _get_chunk_size, _separator), do: []
+  # 2. there's room to add the next split without exceeding chunk_size
+  defp trim_splits_for_overlap([], _current_size, _chunk_overlap, _chunk_size, _next_split_size), do: {[], 0}
 
-  defp trim_splits_for_overlap(current_splits, chunk_overlap, chunk_size, next_split_text, get_chunk_size, separator) do
-    current_texts = Enum.map(current_splits, & &1.text)
-    merged = join_splits(current_texts, separator)
-    current_size = get_chunk_size.(merged || "")
-
-    # Check if adding the next split would exceed chunk_size
-    merged_with_next = join_splits(current_texts ++ [next_split_text], separator)
-    size_with_next = get_chunk_size.(merged_with_next || "")
-
-    # Reduce if:
-    # - size exceeds overlap limit, OR
-    # - adding the next split would exceed chunk_size (and there's something to remove)
-    if current_size > chunk_overlap or (size_with_next > chunk_size and current_size > 0) do
-      [_first_split | rest] = current_splits
-      trim_splits_for_overlap(rest, chunk_overlap, chunk_size, next_split_text, get_chunk_size, separator)
+  defp trim_splits_for_overlap(
+         [{_first_split, first_size} | rest] = current_splits,
+         current_size,
+         chunk_overlap,
+         chunk_size,
+         next_split_size
+       ) do
+    if current_size > chunk_overlap or (current_size + next_split_size > chunk_size and current_size > 0) do
+      trim_splits_for_overlap(rest, current_size - first_size, chunk_overlap, chunk_size, next_split_size)
     else
-      current_splits
+      {current_splits, current_size}
     end
   end
 

--- a/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
+++ b/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
@@ -97,7 +97,9 @@ defmodule TextChunker.Strategies.RecursiveChunk do
               )
 
             if get_chunk_size.(split.text) > chunk_size do
-              fallback_chunks = create_fallback_chunks(split, chunk_size, chunk_overlap, get_chunk_size)
+              fallback_chunks =
+                fallback_splitter(split.text, split.start_byte, chunk_size, chunk_overlap, get_chunk_size, [])
+
               {final_chunks ++ fallback_chunks, []}
             else
               {final_chunks ++ [split], []}
@@ -172,11 +174,14 @@ defmodule TextChunker.Strategies.RecursiveChunk do
           chunk = build_chunk(current_splits)
 
           if get_chunk_size.(chunk.text) > chunk_size do
-            # The overlap is dropped so start bytes stay monotonic.
-            fallback_chunks = create_fallback_chunks(chunk, chunk_size, chunk_overlap, get_chunk_size)
+            fallback_chunks =
+              fallback_splitter(chunk.text, chunk.start_byte, chunk_size, chunk_overlap, get_chunk_size, [])
+
+            # No overlap is carried into the next chunk here: the fallback chunks
+            # already cover the end of `chunk`, so keeping earlier splits would
+            # make the next chunk's start_byte go backwards.
             {final_chunks ++ fallback_chunks, [{split, split_size}], split_size}
           else
-            # Calculate overlap for next chunk, ensuring room for the new split
             {overlap_splits, overlap_size} =
               trim_splits_for_overlap(current_splits, current_size, chunk_overlap, chunk_size, split_size)
 
@@ -251,6 +256,10 @@ defmodule TextChunker.Strategies.RecursiveChunk do
     Enum.reverse(splits)
   end
 
+  # Fallback chunking: the last resort for text that exceeds chunk_size but can
+  # no longer be split on a separator. fallback_splitter/6 slices the text by
+  # character count, binary-searching for the largest prefix that fits within
+  # chunk_size, and keeps chunk_overlap between consecutive slices.
   defp create_fallback_chunks(%Chunk{text: text, start_byte: start_byte}, chunk_size, chunk_overlap, get_chunk_size) do
     text_size = get_chunk_size.(text)
 

--- a/test/recursive_chunk_property_test.exs
+++ b/test/recursive_chunk_property_test.exs
@@ -179,6 +179,22 @@ defmodule TextChunker.RecursiveChunkPropertyTest do
     end
   end
 
+  property "consecutive chunks overlap by no more than chunk_overlap" do
+    check all(text <- input_text(), opts <- chunk_opts()) do
+      text
+      |> TextChunker.split(opts)
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.each(fn [previous, current] ->
+        overlap_bytes = max(previous.end_byte - current.start_byte, 0)
+        overlap_text = binary_part(text, current.start_byte, overlap_bytes)
+
+        assert String.length(overlap_text) <= opts[:chunk_overlap],
+               "chunks share #{inspect(overlap_text)}, more than chunk_overlap " <>
+                 "#{opts[:chunk_overlap]}: #{inspect(previous)} is followed by #{inspect(current)}"
+      end)
+    end
+  end
+
   property "chunk boundaries never split a grapheme, except a CRLF pair" do
     check all(text <- grapheme_safe_text(), opts <- chunk_opts()) do
       boundaries =

--- a/test/recursive_chunk_test.exs
+++ b/test/recursive_chunk_test.exs
@@ -248,6 +248,35 @@ defmodule TextChunkerTest do
       end
     end
 
+    test "the merge loop does not re-measure accumulated text on every step" do
+      # Guards the incremental size tracking in merge_splits_into_chunks: each
+      # split is measured once and chunk boundaries are decided on a running
+      # sum. Re-measuring the accumulated text on every merge step would put
+      # ~190x the input length through get_chunk_size for this text, versus
+      # ~3x with incremental tracking.
+      {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+      measuring_sizer = fn text ->
+        Agent.update(agent, &(&1 + String.length(text)))
+        String.length(text)
+      end
+
+      text = Enum.map_join(1..2000, " ", fn i -> "word#{i}" end)
+
+      TextChunker.split(text,
+        chunk_size: 1000,
+        chunk_overlap: 100,
+        format: :plaintext,
+        get_chunk_size: measuring_sizer
+      )
+
+      total_measured = Agent.get(agent, & &1)
+
+      assert total_measured <= String.length(text) * 10,
+             "get_chunk_size measured #{total_measured} chars for a " <>
+               "#{String.length(text)}-char input; expected at most 10x"
+    end
+
     test "splits text into chunks with lengths that match the original file" do
       {:ok, text} = File.read("test/support/fixtures/document_fixtures/hamlet.txt")
 


### PR DESCRIPTION
Addresses the performance problem in #88. 

This PR touches the heart of the algo, so (unlike other cosmetic changes) reviews would be appreciated! I've done my best to re-familiarize myself with it and review it myself before passing it on to you, but it's a brain bender to be sure.

There's definitely still some room for improvement in here, and dead code that could be cut, but I've tried to keep the diff as minimal as possible.

It also turns out there was a lot of complexity built into our old approach (re-gluing and measuring) so this should actually make things a little cleaner!

## The problem

The chunk-assembly loop re-joined and re-measured the entire accumulated window on every iteration, and again once per dropped split inside the overlap trim. This is *92% of the total runtime of the algo*

## The fix

Each split is measured once and carried as a `{split, size}` pair; chunk boundaries are decided on a running sum of those sizes, so `get_chunk_size` runs once per split instead of once per split-per-window-position. There are a couple of edge cases:

- `String.length/1` counts `"\r" <> "\n"` as one grapheme, which means a split ending in "\r" followed by one starting with "\n" adds 2 to the sum but only 1 to the joined text's measure. 
- If a user provided a custom token counter which rounded, then the sum could in theory undercount, producing a chunk over the chunk size.

This is why every flushed chunk is re-measured once before being emitted, and re-split via create_fallback_chunks/4 in the rare case it comes out over the limit.

Sizes are summed rather than measured on joined text, so we don't need to pass the `separator` around anymore.

## Benchmark

Hamlet plaintext, `chunk_size: 1000, chunk_overlap: 200`, best of 3:

| Input | Before | After |
|-------|--------|-------|
| 187 KB | 0.40 s | 0.010 s |
| 936 KB | 1.93 s | 0.055 s |
| 1.9 MB | 4.11 s | 0.106 s |

### Verification

Full suite + the #87 property tests pass (re-run across 10 seeds).