### PR TITLE
Make chunk assembly linear-time with deep-list accumulation

### DIFF
--- a/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
+++ b/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
@@ -10,6 +10,10 @@ defmodule TextChunker.Strategies.RecursiveChunk do
 
   Both are represented by `%TextChunker.Chunk{}` structs internally; the names refer to their role in the algorithm.
 
+  Throughout the implementation, chunk and split lists are accumulated as deep lists: `[acc, item]`
+  appends in constant time while preserving order, and a single `List.flatten/1` at the point of use
+  restores a flat list. This keeps chunk assembly linear in the number of chunks.
+
   **Key Features:**
 
   * **Size-Guided Chunking:** Prioritizes splitting text into semantic blocks while respecting the maximum `chunk_size`.
@@ -58,7 +62,11 @@ defmodule TextChunker.Strategies.RecursiveChunk do
     chunk_overlap = opts[:chunk_overlap]
     get_chunk_size = opts[:get_chunk_size]
     initial_split = %Chunk{text: text, start_byte: 0, end_byte: byte_size(text)}
-    chunks = perform_split(initial_split, separators, chunk_size, chunk_overlap, get_chunk_size)
+
+    chunks =
+      initial_split
+      |> perform_split(separators, chunk_size, chunk_overlap, get_chunk_size)
+      |> List.flatten()
 
     case chunks do
       [] ->
@@ -84,7 +92,7 @@ defmodule TextChunker.Strategies.RecursiveChunk do
       Enum.reduce(splits_with_positions, {[], []}, fn split, {final_chunks, good_splits} ->
         cond do
           fits_in_chunk?(split, chunk_size, get_chunk_size) ->
-            {final_chunks, good_splits ++ [split]}
+            {final_chunks, [good_splits, split]}
 
           Enum.empty?(remaining_separators) ->
             final_chunks =
@@ -100,9 +108,9 @@ defmodule TextChunker.Strategies.RecursiveChunk do
               fallback_chunks =
                 fallback_splitter(split.text, split.start_byte, chunk_size, chunk_overlap, get_chunk_size, [])
 
-              {final_chunks ++ fallback_chunks, []}
+              {[final_chunks, fallback_chunks], []}
             else
-              {final_chunks ++ [split], []}
+              {[final_chunks, split], []}
             end
 
           true ->
@@ -118,27 +126,21 @@ defmodule TextChunker.Strategies.RecursiveChunk do
             more_chunks =
               perform_split(split, remaining_separators, chunk_size, chunk_overlap, get_chunk_size)
 
-            {final_chunks ++ more_chunks, []}
+            {[final_chunks, more_chunks], []}
         end
       end)
 
-    final_chunks =
-      merge_good_splits_into_final_chunks(
-        good_splits,
-        final_chunks,
-        chunk_size,
-        chunk_overlap,
-        get_chunk_size
-      )
-
-    final_chunks
+    merge_good_splits_into_final_chunks(good_splits, final_chunks, chunk_size, chunk_overlap, get_chunk_size)
   end
 
   ### **Chunk Assembly:**
   defp merge_good_splits_into_final_chunks(good_splits, final_chunks, chunk_size, chunk_overlap, get_chunk_size) do
-    case good_splits do
-      [] -> final_chunks
-      _ -> final_chunks ++ merge_splits_into_chunks(good_splits, chunk_size, chunk_overlap, get_chunk_size)
+    case List.flatten(good_splits) do
+      [] ->
+        final_chunks
+
+      splits ->
+        [final_chunks, merge_splits_into_chunks(splits, chunk_size, chunk_overlap, get_chunk_size)]
     end
   end
 
@@ -170,8 +172,9 @@ defmodule TextChunker.Strategies.RecursiveChunk do
       Enum.reduce(splits, {[], [], 0}, fn split, {final_chunks, current_splits, current_size} ->
         split_size = get_chunk_size.(split.text)
 
-        if current_size + split_size > chunk_size and !Enum.empty?(current_splits) do
-          chunk = build_chunk(current_splits)
+        if current_size + split_size > chunk_size and current_splits != [] do
+          sized_splits = List.flatten(current_splits)
+          chunk = build_chunk(sized_splits)
 
           if get_chunk_size.(chunk.text) > chunk_size do
             fallback_chunks =
@@ -180,25 +183,30 @@ defmodule TextChunker.Strategies.RecursiveChunk do
             # No overlap is carried into the next chunk here: the fallback chunks
             # already cover the end of `chunk`, so keeping earlier splits would
             # make the next chunk's start_byte go backwards.
-            {final_chunks ++ fallback_chunks, [{split, split_size}], split_size}
+            {[final_chunks, fallback_chunks], [{split, split_size}], split_size}
           else
             {overlap_splits, overlap_size} =
-              trim_splits_for_overlap(current_splits, current_size, chunk_overlap, chunk_size, split_size)
+              trim_splits_for_overlap(sized_splits, current_size, chunk_overlap, chunk_size, split_size)
 
-            {final_chunks ++ [chunk], overlap_splits ++ [{split, split_size}], overlap_size + split_size}
+            {[final_chunks, chunk], [overlap_splits, {split, split_size}], overlap_size + split_size}
           end
         else
-          {final_chunks, current_splits ++ [{split, split_size}], current_size + split_size}
+          {final_chunks, [current_splits, {split, split_size}], current_size + split_size}
         end
       end)
 
     # Handle leftover splits
-    case current_splits do
+    case List.flatten(current_splits) do
       [] ->
         final_chunks
 
-      _ ->
-        final_chunks ++ create_fallback_chunks(build_chunk(current_splits), chunk_size, chunk_overlap, get_chunk_size)
+      leftover_splits ->
+        leftover_chunks =
+          leftover_splits
+          |> build_chunk()
+          |> create_fallback_chunks(chunk_size, chunk_overlap, get_chunk_size)
+
+        [final_chunks, leftover_chunks]
     end
   end
 
@@ -241,19 +249,18 @@ defmodule TextChunker.Strategies.RecursiveChunk do
   defp get_splits_with_positions(%Chunk{} = parent_split, separator) do
     split_texts = split_on_separator(separator, parent_split)
 
-    {splits, _} =
-      Enum.reduce(split_texts, {[], parent_split.start_byte}, fn split_text, {acc, current_offset} ->
+    {splits, _final_offset} =
+      Enum.map_reduce(split_texts, parent_split.start_byte, fn split_text, offset ->
         split = %Chunk{
-          start_byte: current_offset,
-          end_byte: current_offset + byte_size(split_text),
+          start_byte: offset,
+          end_byte: offset + byte_size(split_text),
           text: split_text
         }
 
-        next_offset = current_offset + byte_size(split_text)
-        {[split | acc], next_offset}
+        {split, offset + byte_size(split_text)}
       end)
 
-    Enum.reverse(splits)
+    splits
   end
 
   # Fallback chunking: the last resort for text that exceeds chunk_size but can
@@ -270,7 +277,7 @@ defmodule TextChunker.Strategies.RecursiveChunk do
     end
   end
 
-  defp fallback_splitter("", _start_byte, _chunk_size, _chunk_overlap, _get_chunk_size, acc), do: Enum.reverse(acc)
+  defp fallback_splitter("", _start_byte, _chunk_size, _chunk_overlap, _get_chunk_size, acc), do: acc
 
   defp fallback_splitter(text, start_byte, chunk_size, chunk_overlap, get_chunk_size, acc) do
     # Find how many characters fit within chunk_size using the custom sizing function
@@ -286,7 +293,7 @@ defmodule TextChunker.Strategies.RecursiveChunk do
 
     # If we took everything (or overlap would cause no progress), we're done
     if char_count >= total_chars do
-      Enum.reverse([chunk | acc])
+      [acc, chunk]
     else
       # Find how many characters to keep as overlap
       overlap_chars = find_char_count_for_size(chunk_text, chunk_overlap, get_chunk_size)
@@ -294,7 +301,7 @@ defmodule TextChunker.Strategies.RecursiveChunk do
       remaining_text = String.slice(text, next_start..-1//1)
       next_byte_offset = start_byte + byte_size(String.slice(text, 0, next_start))
 
-      fallback_splitter(remaining_text, next_byte_offset, chunk_size, chunk_overlap, get_chunk_size, [chunk | acc])
+      fallback_splitter(remaining_text, next_byte_offset, chunk_size, chunk_overlap, get_chunk_size, [acc, chunk])
     end
   end
 

--- a/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
+++ b/lib/text_chunker/strategies/recursive_chunk/recursive_chunk.ex
@@ -62,6 +62,7 @@ defmodule TextChunker.Strategies.RecursiveChunk do
     chunk_overlap = opts[:chunk_overlap]
     get_chunk_size = opts[:get_chunk_size]
     initial_split = %Chunk{text: text, start_byte: 0, end_byte: byte_size(text)}
+
     initial_split
     |> perform_split(separators, chunk_size, chunk_overlap, get_chunk_size)
     |> List.flatten()


### PR DESCRIPTION
Closes #88.

Chunk and split lists are accumulated as deep lists — `[acc, item]` appends in constant time while preserving document order, and a single `List.flatten/1` at each point of use restores a flat list. This replaces the `list ++ [item]` appends that made assembly quadratic in the number of chunks, and keeps every intermediate list in natural order: no reversed accumulators, no `Enum.reverse` anywhere in the module. The convention is documented in the moduledoc. `get_splits_with_positions` becomes a plain `Enum.map_reduce`.

`split_on_separator`'s per-call regex compilation is out of scope; #97 tracks it.

Hamlet, `chunk_size: 1000, chunk_overlap: 200`, larger inputs via `String.duplicate`:

| Input | Before | After |
|-------|--------|-------|
| 190 KB | 0.01 s | 0.01 s |
| 1.9 MB | 0.11 s | 0.09 s |
| 9.6 MB | 0.71 s | 0.44 s |
| 19 MB | 2.48 s | ~1.05 s |

100x input cost ~250x time before, ~105x after — near-linear, per the issue's acceptance criterion.

Behavior is unchanged, verified three ways: this branch is `main` plus this one file, so CI runs `main`'s test suite verbatim against the refactor; the property suite (#92) passes; and chunk output on Hamlet (`{text, start_byte, end_byte}` per chunk) hashes identically to `main` across five option combos (sizes 50–2000, overlaps 0–200, plaintext and markdown).

Checks: `mix test`, `mix format`, `mix dialyzer`.